### PR TITLE
Add unified GRAPHITE pipeline controller

### DIFF
--- a/config/pipeline_config.yaml
+++ b/config/pipeline_config.yaml
@@ -1,0 +1,27 @@
+pipeline:
+  name: "GRAPHITE_Pipeline"
+  version: "1.0"
+
+paths:
+  data_root: "dataset/"
+  output_root: "outputs/"
+  models_root: "models/"
+
+step_1_mil:
+  epochs: 50
+  batch_size: 16
+  learning_rate: 0.001
+  early_stopping_patience: 10
+
+step_2_ssl:
+  epochs: 100
+  batch_size: 32
+  learning_rate: 0.0001
+
+step_3_xai:
+  methods: ["gradcam", "attention", "lime"]
+  output_format: ["png", "npy"]
+
+step_4_fusion:
+  fusion_method: "weighted_average"
+  attention_weights: [0.4, 0.6]

--- a/integration_interfaces.py
+++ b/integration_interfaces.py
@@ -1,0 +1,58 @@
+from typing import Dict, Any
+from src.data_flow_manager import DataFlowManager
+from src.model_manager import ModelManager
+from src.progress_tracker import ProgressTracker
+
+class StepInterface:
+    """Base interface for all pipeline steps."""
+
+    def __init__(self, config: Dict, data_manager: DataFlowManager,
+                 model_manager: ModelManager, progress_tracker: ProgressTracker):
+        self.config = config
+        self.data_manager = data_manager
+        self.model_manager = model_manager
+        self.progress_tracker = progress_tracker
+
+    def execute(self) -> Dict[str, Any]:
+        raise NotImplementedError
+
+class MILStep(StepInterface):
+    def execute(self) -> Dict[str, Any]:
+        from training_step_1.run_training import main as mil_main
+        self.progress_tracker.start_step("mil", "Training MIL model")
+        results = mil_main()
+        if isinstance(results, dict) and 'model' in results:
+            self.model_manager.save_model(results['model'], 'mil_model', 'step1',
+                                          {'accuracy': results.get('accuracy')})
+        self.data_manager.save_step_output('step1_mil', results if isinstance(results, dict) else {})
+        self.progress_tracker.complete_step("mil", results if isinstance(results, dict) else {})
+        return results if isinstance(results, dict) else {}
+
+class SSLStep(StepInterface):
+    def execute(self) -> Dict[str, Any]:
+        from training_step_2.self_supervised_training.train import main as ssl_main
+        self.progress_tracker.start_step("ssl", "Training HierGAT model")
+        results = ssl_main()
+        if isinstance(results, dict) and 'model' in results:
+            self.model_manager.save_model(results['model'], 'hiergat_model', 'step2')
+        self.data_manager.save_step_output('step2_ssl', results if isinstance(results, dict) else {})
+        self.progress_tracker.complete_step("ssl", results if isinstance(results, dict) else {})
+        return results if isinstance(results, dict) else {}
+
+class XAIStep(StepInterface):
+    def execute(self) -> Dict[str, Any]:
+        from visualization_step_1.xai_visualization.main import main as xai_main
+        self.progress_tracker.start_step("xai", "Running XAI visualization")
+        results = xai_main()
+        self.data_manager.save_step_output('step3_xai', results if isinstance(results, dict) else {})
+        self.progress_tracker.complete_step("xai", results if isinstance(results, dict) else {})
+        return results if isinstance(results, dict) else {}
+
+class FusionStep(StepInterface):
+    def execute(self) -> Dict[str, Any]:
+        from visualization_step_2.fusion_visualization.main_final_fusion import main as fusion_main
+        self.progress_tracker.start_step("fusion", "Running saliency fusion")
+        results = fusion_main()
+        self.data_manager.save_step_output('step4_fusion', results if isinstance(results, dict) else {})
+        self.progress_tracker.complete_step("fusion", results if isinstance(results, dict) else {})
+        return results if isinstance(results, dict) else {}

--- a/main_pipeline.py
+++ b/main_pipeline.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""GRAPHITE end-to-end pipeline controller."""
+import argparse
+import yaml
+from pathlib import Path
+from typing import Dict
+from src.data_flow_manager import DataFlowManager
+from src.model_manager import ModelManager
+from src.progress_tracker import ProgressTracker
+from integration_interfaces import MILStep, SSLStep, XAIStep, FusionStep
+
+
+def load_config(path: str) -> Dict:
+    with open(path, 'r') as f:
+        return yaml.safe_load(f)
+
+
+def generate_pipeline_report(results: Dict, output_dir: str):
+    report_path = Path(output_dir) / 'pipeline_report.yaml'
+    with open(report_path, 'w') as f:
+        yaml.dump(results, f)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GRAPHITE End-to-End Pipeline")
+    parser.add_argument('--config', required=True, help='Path to configuration file')
+    parser.add_argument('--steps', nargs='+', choices=['mil', 'ssl', 'xai', 'fusion'],
+                        help='Specific steps to run')
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+
+    data_manager = DataFlowManager(config)
+    model_manager = ModelManager(config['paths']['models_root'])
+    progress_tracker = ProgressTracker(config['paths']['output_root'])
+
+    steps = {
+        'mil': MILStep(config, data_manager, model_manager, progress_tracker),
+        'ssl': SSLStep(config, data_manager, model_manager, progress_tracker),
+        'xai': XAIStep(config, data_manager, model_manager, progress_tracker),
+        'fusion': FusionStep(config, data_manager, model_manager, progress_tracker)
+    }
+
+    steps_to_run = args.steps or ['mil', 'ssl', 'xai', 'fusion']
+    results = {}
+    for step in steps_to_run:
+        print(f"\n🔄 Executing {step.upper()} step...")
+        results[step] = steps[step].execute()
+
+    generate_pipeline_report(results, config['paths']['output_root'])
+    print("\n✅ Pipeline completed successfully!")
+
+
+if __name__ == '__main__':
+    main()

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -221,6 +221,7 @@ show_menu() {
     echo "9. 📓 Start Jupyter Notebook"
     echo "10. 🐳 Docker Setup"
     echo "11. 📋 System Information"
+    echo "12. 🔄 Complete Pipeline"
     echo "0. 🚪 Exit"
     echo -e "${CYAN}==================================================${NC}"
     echo ""
@@ -268,6 +269,18 @@ train_mil() {
     esac
     cd ../..
 }
+
+run_complete_pipeline() {
+    log "Running complete GRAPHITE pipeline..."
+    mkdir -p outputs/step1_mil outputs/step2_ssl outputs/step3_xai outputs/step4_fusion
+    python main_pipeline.py --config config/pipeline_config.yaml 2>&1 | tee outputs/pipeline.log
+    if [ $? -eq 0 ]; then
+        log "Pipeline completed successfully"
+    else
+        error "Pipeline failed. Check outputs/pipeline.log"
+    fi
+}
+
 
 train_ssl() {
     log "Starting Self-Supervised Learning Training..."
@@ -421,7 +434,7 @@ main() {
     
     while true; do
         show_menu
-        read -p "Please select an option [0-11]: " choice
+        read -p "Please select an option [0-12]: " choice
         
         case $choice in
             1)
@@ -462,12 +475,15 @@ main() {
             11)
                 show_system_info
                 ;;
+            12)
+                run_complete_pipeline
+                ;;
             0)
                 log "Thank you for using GRAPHITE! 🔬"
                 exit 0
                 ;;
             *)
-                error "Invalid option. Please choose 0-11."
+                error "Invalid option. Please choose 0-12."
                 ;;
         esac
         

--- a/src/data_flow_manager.py
+++ b/src/data_flow_manager.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+from typing import Dict
+import torch
+
+class DataFlowManager:
+    """Manage outputs between pipeline steps."""
+
+    def __init__(self, config: Dict):
+        self.config = config
+        self.outputs = {}
+
+    def save_step_output(self, step_name: str, output_data: Dict):
+        """Save output from a pipeline step."""
+        output_root = Path(self.config['paths']['output_root']) / step_name
+        output_root.mkdir(parents=True, exist_ok=True)
+
+        if 'model' in output_data:
+            model = output_data['model']
+            torch.save(model, output_root / 'model.pth')
+
+        if 'metrics' in output_data:
+            with open(output_root / 'metrics.json', 'w') as f:
+                json.dump(output_data['metrics'], f, indent=2)
+
+        self.outputs[step_name] = output_data
+
+    def load_step_output(self, step_name: str) -> Dict:
+        """Load output from a previous step."""
+        return self.outputs.get(step_name, {})

--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+from typing import Dict, Any
+import torch
+
+class ModelManager:
+    """Handle saving and loading of models between pipeline steps."""
+
+    def __init__(self, models_dir: str = "models/"):
+        self.models_dir = Path(models_dir)
+        self.models_dir.mkdir(parents=True, exist_ok=True)
+        self.loaded_models: Dict[str, Any] = {}
+
+    def save_model(self, model: torch.nn.Module, model_name: str, step: str, metadata: Dict = None) -> Path:
+        step_dir = self.models_dir / step
+        step_dir.mkdir(parents=True, exist_ok=True)
+        model_path = step_dir / f"{model_name}.pth"
+        torch.save({
+            'model_state_dict': model.state_dict(),
+            'model_class': model.__class__.__name__,
+            'metadata': metadata or {}
+        }, model_path)
+        return model_path
+
+    def load_model(self, model_class, model_name: str, step: str) -> torch.nn.Module:
+        model_path = self.models_dir / step / f"{model_name}.pth"
+        if not model_path.exists():
+            raise FileNotFoundError(f"Model not found: {model_path}")
+
+        checkpoint = torch.load(model_path, map_location='cpu')
+        model = model_class()
+        model.load_state_dict(checkpoint['model_state_dict'])
+        self.loaded_models[f"{step}_{model_name}"] = {
+            'model': model,
+            'metadata': checkpoint.get('metadata', {})
+        }
+        return model

--- a/src/progress_tracker.py
+++ b/src/progress_tracker.py
@@ -1,0 +1,50 @@
+import time
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+class ProgressTracker:
+    """Track progress of pipeline steps and save logs."""
+
+    def __init__(self, output_dir: str = "outputs/"):
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.start_time = time.time()
+        self.step_times: Dict[str, Dict] = {}
+        self.progress_log = []
+
+    def start_step(self, step_name: str, description: str = ""):
+        self.step_times[step_name] = {'start': time.time()}
+        self.progress_log.append({
+            'timestamp': datetime.now().isoformat(),
+            'step': step_name,
+            'action': 'start',
+            'description': description
+        })
+        self._save_progress()
+
+    def complete_step(self, step_name: str, results: Dict = None):
+        if step_name in self.step_times:
+            self.step_times[step_name]['end'] = time.time()
+            self.step_times[step_name]['duration'] = (
+                self.step_times[step_name]['end'] -
+                self.step_times[step_name]['start']
+            )
+        self.progress_log.append({
+            'timestamp': datetime.now().isoformat(),
+            'step': step_name,
+            'action': 'complete',
+            'duration': self.step_times.get(step_name, {}).get('duration', 0),
+            'results': results or {}
+        })
+        self._save_progress()
+
+    def _save_progress(self):
+        progress_file = self.output_dir / "pipeline_progress.json"
+        with open(progress_file, 'w') as f:
+            json.dump({
+                'total_runtime': time.time() - self.start_time,
+                'step_times': self.step_times,
+                'progress_log': self.progress_log
+            }, f, indent=2)


### PR DESCRIPTION
## Summary
- create config for pipeline steps and paths
- implement DataFlowManager, ModelManager and ProgressTracker utilities
- define integration step interfaces
- add main_pipeline controller script
- extend quickstart script with option to run full pipeline

## Testing
- `python -m py_compile main_pipeline.py integration_interfaces.py src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6840736611088330a27917e32dc8d81b